### PR TITLE
Do not requeue requests that produce exceptions

### DIFF
--- a/cw/worker.py
+++ b/cw/worker.py
@@ -229,11 +229,11 @@ def callback(connection, exchange, routing_key):
             cw.logger.info("Received message with packed body: {}".format(body))
             unpacked_body = __decode_body(msgpack.unpackb(body))
             results = Worker().run(unpacked_body)
-            channel.basic_ack(delivery_tag=method_frame.delivery_tag)
             for result in results:
                 cw.logger.debug("saving result: {} {}".format(result['x'],result['y']))
                 packed_result = msgpack.packb(result)
                 messaging.send(packed_result, channel, exchange, routing_key)
+            channel.basic_ack(delivery_tag=method_frame.delivery_tag)
         except Exception as e:
             cw.logger.error('Unrecoverable error ({}) handling message: {}'.format(e, body))
             channel.basic_nack(delivery_tag=method_frame.delivery_tag, requeue=False)


### PR DESCRIPTION
Right now, failed messages will requeue, eventually bringing all workers down. These messages should be nack'd and not requeued.